### PR TITLE
Give the ability to reuse an existing task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ If you do not wish to store your task definition as a file in your git repositor
         aws ecs describe-task-definition --task-definition my-task-definition-family --query taskDefinition > task-definition.json
 ```
 
+If you don't want to create new revisions of your task definition, you can define the task definition family and revision as inputs for the action. By default, the action will use the latest revision of the task definition family if the revision is not specified.
+
+```yaml
+    - name: Deploy to Amazon ECS
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: my-task-definition-family
+        service: my-service
+        cluster: my-cluster
+        wait-for-service-stability: true
+```
+
 ### Task definition container image values
 
 It is highly recommended that each time your GitHub Actions workflow runs and builds a new container image for deployment, a new container image ID is generated.  For example, use the commit ID as the new image's tag, instead of updating the 'latest' tag with the new image.  Using a unique container image ID for each deployment allows rolling back to a previous container image.

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: 'orange'
 inputs:
   task-definition:
-    description: 'The path to the ECS task definition file to register'
+    description: 'The path to the ECS task definition file to register or the name of the task definition family to use. If the task definition family is given, the action will use the latest ACTIVE revision of the task definition.'
     required: true
   service:
     description: 'The name of the ECS service to deploy to. The action will only register the task definition if no service is given.'

--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     cluster: clusterName,
     service: service,
     taskDefinition: taskDefArn,
-    forceNewDeployment: forceNewDeployment
+    forceNewDeployment: forceNewDeployment,
+    enableExecuteCommand: true, // Always enable execute command in the service definition
   }).promise();
 
   const consoleHostname = aws.config.region.startsWith('cn') ? 'console.amazonaws.cn' : 'console.aws.amazon.com';


### PR DESCRIPTION
Porting https://github.com/aws-actions/amazon-ecs-deploy-task-definition/pull/518 into our fork.

Bonus feature always pass `enableExecuteCommand` to service update command